### PR TITLE
ADCM-1548 any_error_fatal work in block with always;

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -479,23 +479,31 @@ class PlayIterator:
     def _check_failed_state(self, state):
         if state is None:
             return False
-        elif state.run_state == self.ITERATING_RESCUE and self._check_failed_state(state.rescue_child_state):
-            return True
-        elif state.run_state == self.ITERATING_ALWAYS and self._check_failed_state(state.always_child_state):
-            return True
-        elif state.fail_state != self.FAILED_NONE:
-            if state.run_state == self.ITERATING_RESCUE and state.fail_state & self.FAILED_RESCUE == 0:
-                return False
-            elif state.run_state == self.ITERATING_ALWAYS and state.fail_state & self.FAILED_ALWAYS == 0:
-                return False
-            else:
-                return not state.did_rescue
-        elif state.run_state == self.ITERATING_TASKS and self._check_failed_state(state.tasks_child_state):
-            cur_block = self._blocks[state.cur_block]
-            if len(cur_block.rescue) > 0 and state.fail_state & self.FAILED_RESCUE == 0:
-                return False
-            else:
-                return True
+
+        if state.run_state == self.ITERATING_SETUP:
+            return state.fail_state & self.FAILED_SETUP != 0
+
+        if state.run_state == self.ITERATING_TASKS:
+            child_failed = self._check_failed_state(state.tasks_child_state)
+            rescue_available = len(state._blocks[state.cur_block].rescue) > 0
+            rescue_failed = state.fail_state & self.FAILED_RESCUE != 0
+            return child_failed and (not rescue_available or rescue_failed)
+
+        if state.run_state == self.ITERATING_RESCUE:
+            child_failed = self._check_failed_state(state.rescue_child_state)
+            itself_failed = state.fail_state & self.FAILED_RESCUE != 0
+            return child_failed or itself_failed
+
+        if state.run_state == self.ITERATING_ALWAYS:
+            child_failed = self._check_failed_state(state.always_child_state)
+            itself_failed = state.fail_state & self.FAILED_ALWAYS != 0
+            tasks_failed = state.fail_state & self.FAILED_TASKS != 0 and not state.did_rescue
+            return child_failed or itself_failed or tasks_failed
+
+        if state.run_state == self.ITERATING_COMPLETE:
+            failed = state.fail_state != self.FAILED_NONE
+            return failed and not state.did_rescue
+
         return False
 
     def is_failed(self, host):

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -406,21 +406,20 @@ class StrategyModule(StrategyBase):
 
                 # if any_errors_fatal and we had an error, mark all hosts as failed
                 if any_errors_fatal and (len(failed_hosts) > 0 or len(unreachable_hosts) > 0):
-                    dont_fail_states = frozenset([iterator.ITERATING_RESCUE, iterator.ITERATING_ALWAYS])
                     for host in hosts_left:
-                        (s, _) = iterator.get_next_task_for_host(host, peek=True)
-                        # the state may actually be in a child state, use the get_active_state()
-                        # method in the iterator to figure out the true active state
-                        s = iterator.get_active_state(s)
-                        if s.run_state not in dont_fail_states or \
-                           s.run_state == iterator.ITERATING_RESCUE and s.fail_state & iterator.FAILED_RESCUE != 0:
+                        if iterator.is_failed(host):
                             self._tqm._failed_hosts[host.name] = True
                             result |= self._tqm.RUN_FAILED_BREAK_PLAY
                 display.debug("done checking for any_errors_fatal")
 
                 display.debug("checking for max_fail_percentage")
-                if iterator._play.max_fail_percentage is not None and len(results) > 0:
-                    percentage = iterator._play.max_fail_percentage / 100.0
+                max_fail_percentage = iterator._play.max_fail_percentage
+                if task and task.any_errors_fatal:
+                    # explicitely set any_errors_fatal and max_fail_percentage have conflicting behavior
+                    # any_errors_fatal is decided to have priority and max_fail_percentage is (re)setted to 0
+                    max_fail_percentage = 0
+                if max_fail_percentage is not None and len(results) > 0:
+                    percentage = max_fail_percentage / 100.0
 
                     if (len(self._tqm._failed_hosts) / iterator.batch_size) > percentage:
                         for host in hosts_left:


### PR DESCRIPTION
ADCM-1549 any_errors_fatal has priority over max_fail_percentage

##### SUMMARY
ADCM-1548 any_error_fatal work in block with always
ADCM-1549 any_errors_fatal has priority over max_fail_percentage

Fixes ansible#46447
Fixes ansible#31543

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
- linear strategy class
- class PlayIterator

##### ADDITIONAL INFORMATION
see examples in added unit-tests
